### PR TITLE
Fix handling file argument in bfd.Bfd()

### DIFF
--- a/pybfd3/bfd.py
+++ b/pybfd3/bfd.py
@@ -138,7 +138,7 @@ class Bfd(object):
         #
         # Determine if the user passed a file-descriptor or a _file and
         # proceed accordingly.
-        if type(_file) is io.StringIO:
+        if isinstance(_file, io.IOBase):
             # The user specified a file descriptor.
             filename = _file.name
 


### PR DESCRIPTION
I'm using Python 3.8.5, and get the following exception when trying to use objdump CLI tool from pybfd3:
```
ivan@ivanpc:lib$ python -m pybfd3.objdump -d ./python2.7/site-packages/MySQL_python-1.2.5-py2.7-linux-x86_64.egg/_mysql.so 
Invalid file type specified for open operation (<_io.TextIOWrapper name='./python2.7/site-packages/MySQL_python-1.2.5-py2.7-linux-x86_64.egg/_mysql.so' mode='r' encoding='UTF-8'>)
```

It appeared that argparse run DisassembleSectionAction and passing argument as file object, which later used to initialize instance of bfd.Bfd(), but initialization fails as file object is not an instance of io.StringIO and it seems like for now the right way to check if variable is a file object is to check if its instance of io.IOBase.

Also I got the same exception with the following code (and my fix helped):
```
ivan@ivanpc:lib$ python
...
>>> from pybfd3 import bfd
>>> bfd.Bfd(open('./python2.7/site-packages/MySQL_python-1.2.5-py2.7-linux-x86_64.egg/_mysql.so', 'r'))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.8/dist-packages/pybfd3/bfd.py", line 108, in __init__
    self.open(_file, target)
  File "/usr/local/lib/python3.8/dist-packages/pybfd3/bfd.py", line 177, in open
    raise BfdException(
pybfd3.bfd_base.BfdException: Invalid file type specified for open operation (<_io.TextIOWrapper name='./python2.7/site-packages/MySQL_python-1.2.5-py2.7-linux-x86_64.egg/_mysql.so' mode='r' encoding='UTF-8'>)
```
