### PR TITLE
Fix macOS and binutils>=2.29 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,31 @@ Because it seems that **pybfd** is no longer maintained, I decided to create my 
 
 ## Requirements
 
+### Linux
+
 - The **binutils-dev** package must be installed first.
+
+### macOS
+
+The default brew install doesn't include the required library `libiberty`, because of this you need to modify the brew formula to build and install `libiberty`. To do this run:
+
+```
+$ brew edit binutils
+```
+
+Scroll down the `def install` section and add `--enable-install-libiberty` to the `configure` arguments so that it looks like the following:
+
+```
+                          "--disable-nls",
+                          "--enable-install-libiberty"
+    system "make"
+```
+
+Now run the following command to force brew to build locally instead of from a bottle:
+
+```
+$ brew install --build-from-source binutils
+```
 
 ## Install
 

--- a/setup.py
+++ b/setup.py
@@ -87,11 +87,13 @@ class CustomBuildExtension( build_ext ):
         "darwin": {
             "libs": [
                 "/opt/local/lib", # macports
-                "/usr/local/lib", # homebrew
+                "/usr/local/lib", # homebrew 1
+                "/usr/local/opt/binutils/lib", # homebrew 2
             ],
             "includes": [
                 "/opt/local/include", # macports
-                "/usr/local/include", # homebrew
+                "/usr/local/include", # homebrew 1
+                "/usr/local/opt/binutils/include", # homebrew 2
             ],
             "possible-lib-ext": [
                 ".a", # homebrew
@@ -378,8 +380,9 @@ class CustomBuildExtension( build_ext ):
         if self.with_static_binutils or sys.platform == "darwin": # in OSX we always needs a static lib-iverty.
 
             lib_liberty_partialpath = [lib_path for lib_path in libraries_paths]
-            if sys.platform == "darwin": # in osx the lib-iberty is prefixe by "machine" ppc/i386/x86_64
-                lib_liberty_partialpath.append( self._darwin_current_arch() )
+            # NOTE: At least on Catalina, this is no longer the case
+#            if sys.platform == "darwin": # in osx the lib-iberty is prefixe by "machine" ppc/i386/x86_64
+#                lib_liberty_partialpath.append( self._darwin_current_arch() )
             lib_liberty_partialpath.append( "libiberty.a" )
 
             lib_liberty_fullpath = os.path.join(*lib_liberty_partialpath ) # merge the prefix and the path
@@ -412,6 +415,8 @@ class CustomBuildExtension( build_ext ):
             os.environ["ARCHFLAGS"] = "-arch %s" % self._darwin_current_arch()
             # In OSX we've to link against libintl.
             ext_libs.append("intl")
+            # In OSX we also must link against libz
+            ext_libs.append("z")
 
             # TODO: we have to improve the detection of gettext/libintl in OSX.. this is a quick fix.
             dirs = [


### PR DESCRIPTION
I fixed a few issues with installing pybfd3 on macOS Catalina. The few changes I made include:

- Autogenerating the function prototypes for the `print_insn_*` functions missing in binutils>=2.29
- Adds the newer install path for binutils on macOS
- Adds libz to the list of libraries that are linked against for macOS
- Removes the platform prefix from libiberty
- Adds instructions for installing the requirements on macOS due to Homebrew no longer installing libiberty by default

As far as I can tell everything now works on macOS and Ubuntu 20.04