### PR TITLE
Add support for Binutils >= 2.40

### DIFF
--- a/pybfd3/bfd.c
+++ b/pybfd3/bfd.c
@@ -4,6 +4,8 @@
 // Copyright (c) 2013 Groundworks Technologies
 //
 
+// In order to use '#' variant of formats, we must define this on python >= 3.10
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 #include <stdio.h>

--- a/pybfd3/bfd_headers.h
+++ b/pybfd3/bfd_headers.h
@@ -35,3 +35,7 @@ enum PYBFD3_DISASM_CALLBACK_RESULT {
 };
 
 #endif /* PYBFD3_HEADERS */
+
+#ifndef BFD_VMA_FMT
+#define BFD_VMA_FMT PRIx64
+#endif

--- a/pybfd3/opcodes.c
+++ b/pybfd3/opcodes.c
@@ -471,8 +471,11 @@ start_smart_disassemble(disassembler_pointer* pdisasm_ptr, unsigned long offset,
         offset += n; // update the offset for the next disassemble operation.
         disassembled_bytes += n;    // keep track of the number of bytes
                                     // processed.
-
-        py_result = PyEval_CallObject(callback, py_args);
+        #if PY_VERSION_HEX >= 0x03090000
+            py_result = PyObject_Call(callback, py_args, NULL);
+        #else
+            py_result = PyEval_CallObject(callback, py_args);
+        #endif
         Py_XDECREF(py_args);
 
         if (!py_result) {

--- a/pybfd3/opcodes.c
+++ b/pybfd3/opcodes.c
@@ -4,6 +4,9 @@
 // Copyright (c) 2013 Groundworks Technologies
 //
 
+// In order to use '#' variant of formats, we must define this on python >= 3.10
+#define PY_SSIZE_T_CLEAN
+
 #include <Python.h>
 
 #include <stdio.h>

--- a/pybfd3/opcodes.c
+++ b/pybfd3/opcodes.c
@@ -95,6 +95,17 @@ get_disassemble_function(   unsigned long long ull_arch,
     return (disassembler_ftype)NULL;
 }
 
+#ifdef PYBFD3_LIBBFD_INIT_DISASM_INFO_FOUR_ARGS_SIGNATURE
+// bpftrace no operation fprintf for init_disassemble_info
+static int fprintf_styled_nop(void *out __attribute__((unused)),
+                              enum disassembler_style s __attribute__((unused)),
+                              const char *fmt __attribute__((unused)),
+                              ...)
+{
+  return 0;
+}
+#endif
+
 //
 // Name     : initialize_opcodes
 //
@@ -123,8 +134,13 @@ initialize_opcodes()
     memset(pdisasm_ptr, 0, sizeof(disassembler_pointer));
 
     // Zero out structure members
-    init_disassemble_info(&pdisasm_ptr->dinfo, &pdisasm_ptr->sfile, 
-        (fprintf_ftype)__disassemle_printf);
+    #ifdef PYBFD3_LIBBFD_INIT_DISASM_INFO_FOUR_ARGS_SIGNATURE
+        init_disassemble_info(&pdisasm_ptr->dinfo, &pdisasm_ptr->sfile,
+            (fprintf_ftype)__disassemle_printf, fprintf_styled_nop);
+    #else
+        init_disassemble_info(&pdisasm_ptr->dinfo, &pdisasm_ptr->sfile,
+                    (fprintf_ftype)__disassemle_printf);
+    #endif
 
 
     pdisasm_ptr->pfn_disassemble = NULL;

--- a/pybfd3/test_init_disassemble_info.c
+++ b/pybfd3/test_init_disassemble_info.c
@@ -1,0 +1,8 @@
+#define PACKAGE "pybfd3"
+#define PACKAGE_VERSION "0.1.5"
+
+#include <dis-asm.h>
+int main(void) {
+    init_disassemble_info(NULL, NULL, NULL);
+    return 0;
+}

--- a/setup.py
+++ b/setup.py
@@ -223,18 +223,28 @@ class CustomBuildExtension( build_ext ):
             self.with_static_binutils == None)
 
         source_bfd_archs_c = generate_supported_architectures_source(supported_archs, supported_machines)
+        macros = []
         print("[+] Testing for print_insn_i386...")
         try:
             objects = self.compiler.compile(
                 [os.path.join(PACKAGE_DIR, "test_print_insn_i386.c"), ],
                 include_dirs = [self.includes,],
                 )
-            if len(objects) > 0:
-                macros = None
-            else:
+            if len(objects) == 0:
                 macros = [("PYBFD3_BFD_GE_2_29", None)]
         except:
             macros = [("PYBFD3_BFD_GE_2_29", None)]
+
+        print("[+] Testing for init_disassemble_info...")
+        try:
+            objects = self.compiler.compile(
+                [os.path.join(PACKAGE_DIR, "init_disassemble_info.c"), ],
+                include_dirs = [self.includes,],
+            )
+            if len(objects) == 0:
+                macros.append(("PYBFD3_LIBBFD_INIT_DISASM_INFO_FOUR_ARGS_SIGNATURE", None))
+        except:
+            macros.append(("PYBFD3_LIBBFD_INIT_DISASM_INFO_FOUR_ARGS_SIGNATURE", None))
 
         print("[+] Generating .C files...")
         gen_file = os.path.join(PACKAGE_DIR, "gen_bfd_archs.c")

--- a/setup.py
+++ b/setup.py
@@ -238,7 +238,7 @@ class CustomBuildExtension( build_ext ):
         print("[+] Testing for init_disassemble_info...")
         try:
             objects = self.compiler.compile(
-                [os.path.join(PACKAGE_DIR, "init_disassemble_info.c"), ],
+                [os.path.join(PACKAGE_DIR, "test_init_disassemble_info.c"), ],
                 include_dirs = [self.includes,],
             )
             if len(objects) == 0:


### PR DESCRIPTION
Currently pybfd3 fails to build on Python >= 3.10 and binutils >= 2.39. This brings pybfd3 up to date with binutils 2.40 and python 3.10